### PR TITLE
Add option to filter RSS-feed based of store

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Usually a good place to start would be to check Magento CRON's `Schedule Ahead f
 
 ## Changelog
 
+### 2.1.1
+
+- Add section to Admin panel for easy access to Smaily RSS-feed
+- RSS-feed now supports multistore
+
 ### 2.1.0
 
 - Opt-in emails trigger for newsletter from subscribers

--- a/app/code/community/Sendsmaily/Sync/Block/Rss.php
+++ b/app/code/community/Sendsmaily/Sync/Block/Rss.php
@@ -27,16 +27,24 @@ class Sendsmaily_Sync_Block_Rss extends Mage_Rss_Block_Catalog_Abstract
     {
         // Setting cache to save the RSS for 5 minutes.
         $this->setCacheTags(array(self::CACHE_TAG));
-        $this->setCacheKey('sendsmaily_rss_index');
+        $this->setCacheKey(
+            'sendsmaily_rss_index_' .
+            $this->getRequest()->getParam('store_id')
+        );
         $this->setCacheLifetime(300);
     }
 
     protected function _toHtml()
     {
-        $storeId = $this->_getStoreId();
+        // Allow to filter product feed based on store.
+        if (!empty($this->getRequest()->getParam('store_id'))) {
+            $storeId = $this->getRequest()->getParam('store_id');
+        } else {
+            $storeId = $this->_getStoreId(); // From session.
+        }
 
         // Header.
-        $title = Mage::app()->getStore()->getGroup()->getName();
+        $title = Mage::app()->getStore($storeId)->getName();
         $lang = Mage::getStoreConfig('general/locale/code');
         $lastBuildDate = Mage::getSingleton('core/date')->date('D, d M Y H:i:s');
 

--- a/app/code/community/Sendsmaily/Sync/Block/Rss/Url.php
+++ b/app/code/community/Sendsmaily/Sync/Block/Rss/Url.php
@@ -34,8 +34,8 @@ class Sendsmaily_Sync_Block_Rss_Url extends Mage_Adminhtml_Block_System_Config_F
         // Table header.
         $html = '<table style="width:100%">' .
                 '<tr>' .
-                    '<th>Store</th>' .
-                    '<th>Link</th>' .
+                    '<th>' . $this->__('Store') . '</th>' .
+                    '<th>' . $this->__('Link') . '</th>' .
                 '</tr>';
 
         // Add rows.
@@ -56,7 +56,7 @@ class Sendsmaily_Sync_Block_Rss_Url extends Mage_Adminhtml_Block_System_Config_F
             $button = $this->getLayout()->createBlock('adminhtml/widget_button')
                 ->setType('button')
                 ->setClass('scalable')
-                ->setLabel('View RSS-feed')
+                ->setLabel($this->__('View RSS-feed'))
                 ->setOnClick("window.open('$url')")
                 ->toHtml();
 

--- a/app/code/community/Sendsmaily/Sync/Block/Rss/Url.php
+++ b/app/code/community/Sendsmaily/Sync/Block/Rss/Url.php
@@ -25,7 +25,7 @@ class Sendsmaily_Sync_Block_Rss_Url extends Mage_Adminhtml_Block_System_Config_F
      * Creates table with buttons to link to Smaily RSS feed for easy access from admin page.
      *
      * @param Varien_Data_Form_Element_Abstract $element
-     * @return $html Html of button element.
+     * @return $html table of store names with buttons to RSS-feed.
      */
     protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
     {

--- a/app/code/community/Sendsmaily/Sync/Block/Rss/Url.php
+++ b/app/code/community/Sendsmaily/Sync/Block/Rss/Url.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Sendsmaily Sync
+ * Export Magento newsletter subscribers to Sendsmaily
+ * Copyright (C) 2010 Sendsmaily
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class Sendsmaily_Sync_Block_Rss_Url extends Mage_Adminhtml_Block_System_Config_Form_Field
+{
+    /**
+     * Creates table with buttons to link to Smaily RSS feed for easy access from admin page.
+     *
+     * @param Varien_Data_Form_Element_Abstract $element
+     * @return $html Html of button element.
+     */
+    protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
+    {
+        $this->setElement($element);
+        $stores = Mage::app()->getStores();
+        // Table header.
+        $html = '<table style="width:100%">' .
+                '<tr>' .
+                    '<th>Store</th>' .
+                    '<th>Link</th>' .
+                '</tr>';
+
+        // Add rows.
+        foreach ($stores as $store) {
+            $element = '<tr>';
+            $element .= '<td>' . $store->getName() . '</td>';
+
+            $url = $this->getUrl(
+                'sync/rss',
+                array(
+                    '_use_rewrite' => true,
+                    'key'          => '', // Remove key from generated URL.
+                    '_query'       => array(
+                        'store_id'     => $store->getId()
+                    )
+                )
+            );
+            $button = $this->getLayout()->createBlock('adminhtml/widget_button')
+                ->setType('button')
+                ->setClass('scalable')
+                ->setLabel('View RSS-feed')
+                ->setOnClick("window.open('$url')")
+                ->toHtml();
+
+            $element .= '<td>' . $button . '</td>';
+            $element .= '</tr>';
+
+            $html .= $element;
+        }
+
+        $html .= '</table>';
+
+        return $html;
+    }
+}

--- a/app/code/community/Sendsmaily/Sync/etc/config.xml
+++ b/app/code/community/Sendsmaily/Sync/etc/config.xml
@@ -22,7 +22,7 @@
 <config>
   <modules>
     <Sendsmaily_Sync>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </Sendsmaily_Sync>
   </modules>
 

--- a/app/code/community/Sendsmaily/Sync/etc/system.xml
+++ b/app/code/community/Sendsmaily/Sync/etc/system.xml
@@ -86,10 +86,28 @@
               <validate>required-entry</validate>
             </password>
 
+            <rss_feed_section translate="label comment">
+              <label>RSS-feed</label>
+              <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
+              <sort_order>20</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>0</show_in_store>
+            </rss_feed_section>
+
+            <rss_url translate="label">
+              <label>RSS URL</label>
+              <frontend_model>sync/rss_url</frontend_model>
+              <sort_order>21</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>0</show_in_store>
+            </rss_url>
+
             <synchronization_section translate="label">
               <label>Customer synchronization</label>
               <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
-              <sort_order>20</sort_order>
+              <sort_order>30</sort_order>
               <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>
               <show_in_store>0</show_in_store>
@@ -99,7 +117,7 @@
               <label>Enabled</label>
               <frontend_type>select</frontend_type>
               <source_model>adminhtml/system_config_source_yesno</source_model>
-              <sort_order>21</sort_order>
+              <sort_order>31</sort_order>
               <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>
               <show_in_store>0</show_in_store>
@@ -110,7 +128,7 @@
               <comment>Select fields you wish to synchronize along with subscription data</comment>
               <frontend_type>multiselect</frontend_type>
               <source_model>sync/system_config_source_customer_fields</source_model>
-              <sort_order>23</sort_order>
+              <sort_order>32</sort_order>
               <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>
               <show_in_store>0</show_in_store>
@@ -123,7 +141,7 @@
               <label>How often do you want to synchronize?</label>
               <frontend_type>select</frontend_type>
               <source_model>sync/system_config_source_customer_schedule</source_model>
-              <sort_order>24</sort_order>
+              <sort_order>33</sort_order>
               <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>
               <show_in_store>0</show_in_store>

--- a/app/code/community/Sendsmaily/Sync/etc/system.xml
+++ b/app/code/community/Sendsmaily/Sync/etc/system.xml
@@ -96,7 +96,6 @@
             </rss_feed_section>
 
             <rss_url translate="label">
-              <label>RSS URL</label>
               <frontend_model>sync/rss_url</frontend_model>
               <sort_order>21</sort_order>
               <show_in_default>1</show_in_default>

--- a/app/locale/et_EE/Sendsmaily_Sync.csv
+++ b/app/locale/et_EE/Sendsmaily_Sync.csv
@@ -35,3 +35,7 @@
 "Secret key", "Privaatne võti"
 "Error validating CAPTCHA!", "Viga CAPTCHA valideerimisel!"
 "Error loading CAPTCHA!", "Viga CAPTCHA laadimisel!"
+"Store", "Pood"
+"Link","Link"
+"View RSS-feed", "Vaata RSS-kanalit"
+"RSS-feed", "RSS-kanal"


### PR DESCRIPTION
I found out, when creating the RSS-feed section to Admin page, that the current implementation of getting `storeId` got the ID from customer session.
https://github.com/sendsmaily/Sendsmaily-Sync-for-Magento/blob/0206af896fce1a03aabe4d6074ae8b9616fab818/app/code/community/Sendsmaily/Sync/Block/Rss.php#L36

That means it may provide mixed results. This update adds an option to target a specific store and to move directly to that RSS-feed from the admin page.
![image](https://user-images.githubusercontent.com/22918359/70995284-d95d0c00-20d8-11ea-86a8-a53af1e0db26.png)
