### PR TITLE
Initial docker-compose for magento 1

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM alexcheng/magento:latest
+
+# Set up build arguments.
+ARG user_id
+ARG group_id
+ARG username
+ARG group
+
+# Isntall GIT. Required to allow symlinks with modman after SUPEE-9767v2 patch.
+RUN apt-get update && apt-get install -y git
+
+# Set up local user.
+RUN if grep -q ${group} /etc/group; then \
+       groupmod -g ${group_id} ${group}; \
+    else \
+       groupadd -f -g ${group_id} ${group}; \
+    fi \
+    && useradd -m -u ${user_id} -g ${group_id} ${username} -s /bin/bash
+
+# Add local www-data group to the user
+RUN usermod -a -G www-data ${username}

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         - group
         - group_id
     ports:
-      - "80:80"
+      - "8080:80"
     environment:
       - MYSQL_HOST=db
       - MYSQL_DATABASE=magento1
@@ -21,7 +21,7 @@ services:
       - MAGENTO_LOCALE=et_EE
       - MAGENTO_TIMEZONE=Europe/Tallinn
       - MAGENTO_DEFAULT_CURRENCY=EUR
-      - MAGENTO_URL=http://127.0.0.1/
+      - MAGENTO_URL=http://127.0.0.1:8080/
       - MAGENTO_ADMIN_FIRSTNAME=admin
       - MAGENTO_ADMIN_LASTNAME=admin
       - MAGENTO_ADMIN_EMAIL=smlydev@smly.com
@@ -35,13 +35,14 @@ services:
 
   db:
     container_name: magento1_db
-    image: bitnami/mariadb:10.3
+    image: mysql:5.7
     environment:
-      - MARIADB_ROOT_USER=db_user
-      - MARIADB_ROOT_PASSWORD=db_password
-      - MARIADB_DATABASE=magento1
+      - MYSQL_USER=db_user
+      - MYSQL_PASSWORD=db_password
+      - MYSQL_ROOT_PASSWORD=db_password
+      - MYSQL_DATABASE=magento1
     volumes:
-      - magento1-db-data:/bitnami/mariadb
+      - magento1-db-data:/var/lib/mysql
 
 volumes:
   magento1-data:

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -3,7 +3,14 @@ version: '3.7'
 services:
   magento1:
     container_name: magento1
-    image: alexcheng/magento:latest
+    image: sendsmaily/magento1
+    build:
+      context: .
+      args:
+        - username
+        - user_id
+        - group
+        - group_id
     ports:
       - "80:80"
     environment:
@@ -14,14 +21,15 @@ services:
       - MAGENTO_LOCALE=et_EE
       - MAGENTO_TIMEZONE=Europe/Tallinn
       - MAGENTO_DEFAULT_CURRENCY=EUR
-      - MAGENTO_URL=http://dev.magento
+      - MAGENTO_URL=http://127.0.0.1/
       - MAGENTO_ADMIN_FIRSTNAME=admin
       - MAGENTO_ADMIN_LASTNAME=admin
       - MAGENTO_ADMIN_EMAIL=smlydev@smly.com
       - MAGENTO_ADMIN_USERNAME=smailydev
       - MAGENTO_ADMIN_PASSWORD=smailydev1
     volumes:
-      - magento-data:/var/www/html
+      - magento1-data:/var/www/html
+      - ../.:/var/www/html/smailyformagento1
     depends_on:
       - db
 
@@ -33,8 +41,8 @@ services:
       - MARIADB_ROOT_PASSWORD=db_password
       - MARIADB_DATABASE=magento1
     volumes:
-      - db-data:/bitnami/mariadb
+      - magento1-db-data:/bitnami/mariadb
 
 volumes:
-  db-data:
-  magento-data:
+  magento1-data:
+  magento1-db-data:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Overview
+
+This is helper documentation for setting up a development environment for developing the Smaily extension for Magneto 1. This development environment solution is using [docker-compose](https://docs.docker.com/compose/) for setting up Magento and MariaDB connection. Magneto container is based of [alexcheng1982 docker image](https://github.com/alexcheng1982/docker-magento).
+
+## Setting up environment
+
+This workflow uses [Tusk](https://rliebz.github.io/tusk/) - YAML-based task runner - to run tasks.
+To see all available commands run:
+```
+tusk -h
+```
+
+## Building
+
+To mirror local user to container you need to build the image first. Tusk file manages local user information. To mirror a different user you can modify default option values(`tusk build -h`).
+```
+tusk build
+```
+
+## Starting containers
+
+Starting and stopping containers have a shortcut Tusk commands available so that you can start and stop containers from this folder.
+
+To start the containers run:
+```
+tusk up
+```
+And to stop the containers run:
+```
+tusk down
+```
+
+## Installing sample-data
+
+**Installation of the sample-data must happen before you install Magento**
+
+This Magento image has a built-in script to install sample data. To install sample-data run:
+
+```
+tusk install-sampledata
+```
+
+## Installing Magento
+
+This Magento image has a built-in script for Magento installation. To install Magento run:
+```
+tusk install-magento
+```
+
+## Installing Smaily For Magento module
+
+To keep all the module files in a single folder we use [Modman](https://github.com/colinmollenhour/modman). Modman creates symlinks so you don't have to mix your extension files throughout the core code directories.
+
+To install Smaily For Magento extension run:
+```
+tusk install-smaily
+```
+
+
+### Symlinks
+
+The Smaily installation script uses [Allow Symlinks](https://github.com/sreichel/magento-StackExchange_AllowSymlink) extension so that we can use Modman for linking our extension files to Magento directories. The [SUPEE-9767 V2 released July 12th, 2017](https://magento.stackexchange.com/questions/183443/supee-9767-v2-possible-problems-and-solved-issues) patch removes Allow Symlinks section from Magento Admin.
+
+**Check that you have symlinks enabled**
+
+```System > Configuration > Advanced > Developer > Template Settings > Allow Symlinks```
+
+When you create new files you need to let also Modman know about where to create new links.
+
+After creating a new file add the routing description to `modman` file. 
+
+You can update symlinks in container with tusk command:
+```
+tusk update-symlinks
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.7'
+
+services:
+  magento1:
+    container_name: magento1
+    image: alexcheng/magento:latest
+    ports:
+      - "80:80"
+    environment:
+      - MYSQL_HOST=db
+      - MYSQL_DATABASE=magento1
+      - MYSQL_USER=db_user
+      - MYSQL_PASSWORD=db_password
+      - MAGENTO_LOCALE=et_EE
+      - MAGENTO_TIMEZONE=Europe/Tallinn
+      - MAGENTO_DEFAULT_CURRENCY=EUR
+      - MAGENTO_URL=http://dev.magento
+      - MAGENTO_ADMIN_FIRSTNAME=admin
+      - MAGENTO_ADMIN_LASTNAME=admin
+      - MAGENTO_ADMIN_EMAIL=smlydev@smly.com
+      - MAGENTO_ADMIN_USERNAME=smailydev
+      - MAGENTO_ADMIN_PASSWORD=smailydev1
+    volumes:
+      - magento-data:/var/www/html
+    depends_on:
+      - db
+
+  db:
+    container_name: magento1_db
+    image: bitnami/mariadb:10.3
+    environment:
+      - MARIADB_ROOT_USER=db_user
+      - MARIADB_ROOT_PASSWORD=db_password
+      - MARIADB_DATABASE=magento1
+    volumes:
+      - db-data:/bitnami/mariadb
+
+volumes:
+  db-data:
+  magento-data:

--- a/modman
+++ b/modman
@@ -1,0 +1,5 @@
+app/code/community/Sendsmaily/Sync                  app/code/community/Sendsmaily/Sync
+app/design/frontend/base/default/layout/*           app/design/frontend/base/default/layout/
+app/design/frontend/base/default/template/sync/*    app/design/frontend/base/default/template/sync/
+app/etc/modules/*                                   app/etc/modules/
+app/locale/et_EE/*                                  app/locale/et_EE/

--- a/tusk.yml
+++ b/tusk.yml
@@ -1,0 +1,10 @@
+tasks:
+  up:
+    run: docker-compose up -d
+  down:
+    run: docker-compose down
+  install-sampledata:
+    run: docker exec -it magento1 install-sampledata
+  install-magento:
+    run: docker exec -it magento1 install-magento
+  

--- a/tusk.yml
+++ b/tusk.yml
@@ -1,10 +1,55 @@
 tasks:
+  build:
+    usage: Build the Magento image
+    options:
+      username:
+        usage: Username to use for base images
+        default:
+          command: id -un
+      user_id:
+        usage: User id to use for base images
+        default:
+          command: id -u
+      group:
+        usage: User group name to use for base images
+        default:
+          command: id -gn
+      group_id:
+        usage: User group id to use for base images
+        default:
+          command: id -g
+    run:
+      - command: >
+          docker-compose -f ./.docker/docker-compose.yml build
+          --build-arg username=${username}
+          --build-arg user_id=${user_id}
+          --build-arg group=${group}
+          --build-arg group_id=${group_id}
+      - command: docker image prune -f
+
   up:
-    run: docker-compose up -d
+    usage: Start containers
+    run: docker-compose -f ./.docker/docker-compose.yml up -d
+
   down:
-    run: docker-compose down
+    usage: Stop containers
+    run: docker-compose -f ./.docker/docker-compose.yml down
+
   install-sampledata:
+    usage: Install sample-data for Magento store
     run: docker exec -it magento1 install-sampledata
+
   install-magento:
+    usage: Install Magento from CLI
     run: docker exec -it magento1 install-magento
-  
+
+  install-smaily:
+    usage: Install Smaily module into the container
+    run:
+      - command: docker exec -it magento1 modman init
+      - command: docker exec -it magento1 modman clone https://github.com/sreichel/magento-StackExchange_AllowSymlink.git
+      - command: docker exec -it magento1 modman link /var/www/html/smailyformagento1
+
+  update-symlinks:
+    usage: Update symlinks in container
+    run: docker exec -it magento1 modman deploy smailyformagento1


### PR DESCRIPTION
Adds initial Docker compose for Magento 1 module development.

Adds initial tusk files for easy shortcuts to install sample data and magneto.